### PR TITLE
#63_Message_on_empty_stuff_list

### DIFF
--- a/web/src/app/stuff-list/stuff-list.component.html
+++ b/web/src/app/stuff-list/stuff-list.component.html
@@ -1,4 +1,7 @@
-<ul class="list-group">
+<div class="alert alert-info" *ngIf="!stuffList.length" role="alert">
+  There is no stuff yet. <a href="/stuff/add" class="alert-link">Create new one</a>
+</div>
+<ul class="list-group" *ngIf="stuffList.length">
   <li class="list-group-item" *ngFor="let stuff of stuffList">
     <div class="btn-group d-flex">
 

--- a/web/src/app/stuff-list/stuff-list.component.spec.ts
+++ b/web/src/app/stuff-list/stuff-list.component.spec.ts
@@ -1,14 +1,27 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import {HttpClientTestingModule, HttpTestingController} from "@angular/common/http/testing";
+import { By } from '@angular/platform-browser';
 
 import {StuffListComponent} from './stuff-list.component';
+import { Stuff } from '../_models';
+import { StuffService } from '../_services/stuff.service';
+import { UserService } from '../_services';
+import { ConfigService } from '../_services/config.service';
 
-xdescribe('StuffListComponent', () => {
+describe('StuffListComponent', () => {
   let component: StuffListComponent;
   let fixture: ComponentFixture<StuffListComponent>;
+  let testStuffArray: Stuff[] = [
+    {id: 1, name: 'testUser1', description: 'TestDescription1', categories: []},
+    {id: 2, name: 'testUser2', description: 'TestDescription2', categories: []}
+  ];
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [StuffListComponent]
+      declarations: [StuffListComponent],
+      imports: [RouterTestingModule, HttpClientTestingModule],
+      providers: [StuffService, UserService, ConfigService ]
     })
       .compileComponents();
   }));
@@ -21,5 +34,16 @@ xdescribe('StuffListComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should show a list of stuff', () => {
+    expect(testStuffArray).toBeTruthy();
+    expect(fixture.debugElement.query(By.css('ul'))).toBeDefined();
+  });
+  it('should show message and hide list if the list is empty', () => {
+    testStuffArray = [];
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.css('.alert-info'))).toBeDefined();
+    expect(fixture.debugElement.query(By.css('ul'))).toBeNull();
   });
 });

--- a/web/src/app/stuff-list/stuff-list.component.ts
+++ b/web/src/app/stuff-list/stuff-list.component.ts
@@ -25,14 +25,14 @@ export class StuffListComponent implements OnInit {
     console.log(id);
     this.stuffService.delete(id).subscribe(() => this._deleteFromCache(id));
   }
-
+  
   private _deleteFromCache(id) {
     console.log(this.stuffList);
-    for (let stuffIndex in this.stuffList) {
-      let stuff = this.stuffList[stuffIndex];
+    for (let i = 0; i < this.stuffList.length; i++) {
+      let stuff = this.stuffList[i];
       console.log(stuff);
-      if (stuff['id'] === id) {
-        this.stuffList.splice(+stuffIndex, 1);
+        if (stuff['id'] === id) {
+        this.stuffList.splice(i, 1);
       }
     }
   }

--- a/web/src/app/stuff-list/stuff-list.component.ts
+++ b/web/src/app/stuff-list/stuff-list.component.ts
@@ -1,6 +1,8 @@
 import {Component, OnInit} from '@angular/core';
 import {StuffService} from "../_services/stuff.service";
 
+import{ Stuff } from '../_models/Stuff';
+
 @Component({
   selector: 'stuff-list',
   templateUrl: './stuff-list.component.html',
@@ -8,7 +10,7 @@ import {StuffService} from "../_services/stuff.service";
 })
 export class StuffListComponent implements OnInit {
 
-  public stuffList;
+  public stuffList: Stuff[] = [];
 
   constructor(private stuffService: StuffService) {
   }
@@ -30,7 +32,7 @@ export class StuffListComponent implements OnInit {
       let stuff = this.stuffList[stuffIndex];
       console.log(stuff);
       if (stuff['id'] === id) {
-        this.stuffList.splice(stuffIndex, 1);
+        this.stuffList.splice(+stuffIndex, 1);
       }
     }
   }


### PR DESCRIPTION
Added conditions to show either stuff list or message:
`<div class="alert alert-info" *ngIf="!stuffList.length" role="alert">`, `<ul class="list-group" *ngIf="stuffList.length">`
Declared stuffList properly `public stuffList: Stuff[] = []; `, so it can be fully used in the view.
Added simple unit-tests.

Closes #63 